### PR TITLE
7 unsubscribe sad path

### DIFF
--- a/app/controllers/api/v0/subscriptions_controller.rb
+++ b/app/controllers/api/v0/subscriptions_controller.rb
@@ -14,6 +14,8 @@ class Api::V0::SubscriptionsController < ApplicationController
     if sub[:status] == 'active'
       sub.update!(status: 'inactive')
       render json: SubscriptionSerializer.new(sub), status: 200
+    else
+      render json: { error: 'Subscription is already inactive' }, status: 400
     end
   end
 

--- a/spec/requests/subscription_request_spec.rb
+++ b/spec/requests/subscription_request_spec.rb
@@ -176,6 +176,10 @@ RSpec.describe "POST Subscription", type: :request do
         expect(response.status).to eq(400)
         
         error = JSON.parse(response.body, symbolize_names: true)
+     
+        expect(error).to be_a(Hash)
+        expect(error).to have_key(:error)
+        expect(error[:error]).to eq('Subscription is already inactive')
       end
     end
   end


### PR DESCRIPTION
Small PR
This contains sad path tests for trying to deactivate an already inactive subscription.
Custom error message written in controller.

Note: This controller will need updated at a later time to implement switching from 'inactive' to 'active'. OR do we just make a new record instead?